### PR TITLE
Major revision to the `schema.prisma`

### DIFF
--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -13,30 +13,31 @@ generator client {
 // --------------------------------------
 
 model User {
-  id             Int      @id @default(autoincrement())
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-  username       String   @unique
-  firstName      String?
-  lastName       String?
-  email          String   @unique
-  hashedPassword String?
-  role           String   @default("USER")
-  institution    String?
-  language       String   @default("en-US")
-  tos            Boolean?
-  orcid          String?
-
-  tokens   Token[]
-  sessions Session[]
-
-  contributions    Contributor[]
-  forms            Forms[]
-  notifications    Notification[] @relation("UserNotifications")
-  contributorLabel Label[]
-
-  widgets       Widget[]
-  projectWidget ProjectWidget[]
+  id               Int                @id @default(autoincrement())
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+  hashedPassword   String?
+  role             String             @default("USER")
+  tos              Boolean?
+  tokens           Token[]
+  sessions         Session[]
+  // notifications and dashboards
+  notifications    Notification[]     @relation("UserNotifications")
+  widgets          Widget[]
+  projectWidget    ProjectWidget[]
+  // profile information
+  orcid            String?
+  institution      String?
+  username         String             @unique
+  firstName        String?
+  lastName         String?
+  email            String             @unique
+  language         String             @default("en-US")
+  // relational information
+  projects         ProjectMember[]
+  forms            Form[]
+  roles            Role[]
+  ProjectPrivilege ProjectPrivilege[]
 }
 
 model Session {
@@ -49,9 +50,8 @@ model Session {
   antiCSRFToken      String?
   publicData         String?
   privateData        String?
-
-  user   User? @relation(fields: [userId], references: [id])
-  userId Int?
+  user               User?     @relation(fields: [userId], references: [id])
+  userId             Int?
 }
 
 model Token {
@@ -60,128 +60,149 @@ model Token {
   updatedAt   DateTime @updatedAt
   hashedToken String
   type        String
-  // See note below about TokenType enum
-  // type        TokenType
   expiresAt   DateTime
   sentTo      String
-
-  user   User @relation(fields: [userId], references: [id])
-  userId Int
+  user        User     @relation(fields: [userId], references: [id])
+  userId      Int
 
   @@unique([hashedToken, type])
 }
 
-// NOTE: It's highly recommended to use an enum for the token type
-//       but enums only work in Postgres.
-//       See: https://blitzjs.com/docs/database-overview#switch-to-postgre-sql
-// enum TokenType {
-//   RESET_PASSWORD
-// }
-
-enum ContributorPrivileges {
+// controls the privileges at the project level
+enum MemberPrivileges {
   PROJECT_MANAGER
   CONTRIBUTOR
 }
 
-model Contributor {
-  createdAt           DateTime              @default(now())
-  id                  Int                   @id @default(autoincrement())
-  userId              Int
-  projectId           Int
-  user                User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  project             Project               @relation(fields: [projectId], references: [id])
-  assignments         Assignment[]
-  privilege           ContributorPrivileges @default(PROJECT_MANAGER)
-  teams               Team[]
-  tasks               Task[]
-  deleted             Boolean               @default(false)
-  assignmentStatusLog AssignmentStatusLog[]
-  // allow them to have multiple contributor labels, I think like the task array?
-  // add contributor label link here
-  labels              Label[]
+// enrolls people into projects and groups them into teams if necessary
+// keep all information over here for transparency purposes
+model ProjectMember {
+  id                 Int       @id @default(autoincrement())
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  // null if only one person
+  name               String
+  projectId          Int
+  project            Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  //can be one person or many
+  users              User[]
+  tasks              Task[]
+  roles              Role[]
+  deleted            Boolean   @default(false)
+  taskLogAssignedTo  TaskLog[] @relation("assignedTo")
+  taskLogCompletedBy TaskLog[] @relation("completedBy")
+}
+
+// when someone is deleted from a project
+// delete their row from here
+model ProjectPrivilege {
+  createdAt DateTime         @default(now())
+  id        Int              @id @default(autoincrement())
+  userId    Int
+  projectId Int
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  project   Project          @relation(fields: [projectId], references: [id])
+  privilege MemberPrivileges @default(PROJECT_MANAGER)
 }
 
 // Invites
 model Invitation {
-  createdAt      DateTime              @default(now())
-  id             Int                   @id @default(autoincrement())
+  createdAt      DateTime         @default(now())
+  id             Int              @id @default(autoincrement())
   projectId      Int
-  project        Project               @relation(fields: [projectId], references: [id])
+  project        Project          @relation(fields: [projectId], references: [id])
   invitationCode String
-  labels         Label[]
+  roles          Role[]
   email          String
-  privilege      ContributorPrivileges @default(CONTRIBUTOR)
+  privilege      MemberPrivileges @default(CONTRIBUTOR)
   addedBy        String
 }
 
-// Contribution type
-model Label {
-  id           Int           @id @default(autoincrement())
-  userId       Int
-  user         User          @relation(fields: [userId], references: [id])
-  name         String
-  description  String?
-  taxonomy     String?
-  tasks        Task[]
-  contributors Contributor[]
-  invitation   Invitation[]
+// these are used to label the "roles" within a project like credit
+model Role {
+  id             Int             @id @default(autoincrement())
+  userId         Int
+  user           User            @relation(fields: [userId], references: [id])
+  name           String
+  description    String?
+  taxonomy       String?
+  projects       Project[]
+  tasks          Task[]
+  projectMembers ProjectMember[]
+  Invitation     Invitation?     @relation(fields: [invitationId], references: [id])
+  invitationId   Int?
 }
 
+// the overall project structure
 model Project {
-  id            Int             @id @default(autoincrement())
-  createdAt     DateTime        @default(now())
-  updatedAt     DateTime        @updatedAt
-  name          String
-  description   String?
-  abstract      String?
-  keywords      String?
-  citation      String?
-  publisher     String?
-  identifier    String?
-  tasks         Task[]
-  elements      Element[]
-  columns       Column[]
-  contributors  Contributor[]
-  teams         Team[]
-  projectWidget ProjectWidget[]
-  notifications Notification[]
-
-  invitations Invitation[]
+  id               Int                @id @default(autoincrement())
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+  // project metadata
+  name             String
+  description      String?
+  abstract         String?
+  keywords         String?
+  citation         String?
+  publisher        String?
+  identifier       String?
+  // project relations
+  tasks            Task[]
+  elements         Element[]
+  containers       KanbanBoard[]
+  projectMembers   ProjectMember[]
+  roles            Role[]
+  projectWidget    ProjectWidget[]
+  notifications    Notification[]
+  ProjectPrivilege ProjectPrivilege[]
+  Invitation       Invitation[]
 }
 
-enum TaskStatus {
+// status naming
+enum Status {
   COMPLETED
   NOT_COMPLETED
 }
 
+// give people things to do
 model Task {
-  id              Int          @id @default(autoincrement())
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
-  createdBy       Contributor  @relation(fields: [createdById], references: [id], onDelete: Cascade)
-  createdById     Int
-  deadline        DateTime?
-  name            String
-  description     String?
-  columnId        Int
-  columnTaskIndex Int
-  column          Column       @relation(fields: [columnId], references: [id])
-  projectId       Int
-  project         Project      @relation(fields: [projectId], references: [id])
-  elementId       Int?
-  element         Element?     @relation(fields: [elementId], references: [id])
-  assignees       Assignment[]
-  formVersionId   Int?
-  formVersion     FormVersion? @relation(fields: [formVersionId], references: [id], onDelete: Cascade)
-  status          TaskStatus   @default(NOT_COMPLETED)
-  tags            String?
+  id          Int           @id @default(autoincrement())
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  createdBy   ProjectMember @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  createdById Int
+  // task metadata
+  deadline    DateTime?
+  name        String
+  description String?
+  tags        String?
 
-  labels Label[]
+  // check the kanban board coding
+  containerId Int
+  container   KanbanBoard @relation(fields: [containerId], references: [id])
+
+  // task relations
+  projectId     Int
+  project       Project      @relation(fields: [projectId], references: [id])
+  elementId     Int?
+  element       Element?     @relation(fields: [elementId], references: [id])
+  formVersionId Int?
+  formVersion   FormVersion? @relation(fields: [formVersionId], references: [id], onDelete: Cascade)
+  status        Status       @default(NOT_COMPLETED)
+  taskLogs      TaskLog[]
+  roles         Role[]
 }
 
-enum AssignmentStatus {
-  COMPLETED
-  NOT_COMPLETED
+// project kanban board view
+model KanbanBoard {
+  id             Int      @id @default(autoincrement())
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  name           String   @default("To Do") // Might not need this
+  tasks          Task[]
+  containerOrder Int
+  projectId      Int
+  project        Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }
 
 enum CompletedAs {
@@ -189,55 +210,30 @@ enum CompletedAs {
   TEAM
 }
 
-model AssignmentStatusLog {
-  id           Int              @id @default(autoincrement())
-  createdAt    DateTime         @default(now())
-  assignmentId Int
-  assignment   Assignment       @relation(fields: [assignmentId], references: [id], onDelete: Cascade)
-  status       AssignmentStatus @default(NOT_COMPLETED)
-  metadata     Json?
-  completedBy  Int?
-  completedAs  CompletedAs      @default(INDIVIDUAL)
-  contributor  Contributor?     @relation(fields: [completedBy], references: [id], onDelete: SetNull)
+model TaskLog {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) //tells us when things happened
+  status    Status   @default(NOT_COMPLETED) //tells us if it done
+  metadata  Json?
 
-  @@unique([assignmentId, createdAt])
+  // this helps with showing to the users so we don't have go back to projectMember table
+  completedAs CompletedAs @default(INDIVIDUAL)
+
+  // who or which team should be assigned the task
+  assignedToId Int
+  assignedTo   ProjectMember @relation("assignedTo", fields: [assignedToId], references: [id])
+
+  // this is who does the task who might not be assigned like the project manager
+  // this should be the id of the user (singular)
+  completedById Int?
+  completedBy   ProjectMember? @relation("completedBy", fields: [completedById], references: [id])
+
+  // what is the task this is tied to
+  taskId Int
+  task   Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
 }
 
-model Assignment {
-  id            Int                   @id @default(autoincrement())
-  createdAt     DateTime              @default(now())
-  updatedAt     DateTime              @updatedAt
-  taskId        Int
-  task          Task                  @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  contributorId Int?
-  contributor   Contributor?          @relation(fields: [contributorId], references: [id], onDelete: SetNull)
-  teamId        Int?
-  team          Team?                 @relation(fields: [teamId], references: [id], onDelete: SetNull)
-  statusLogs    AssignmentStatusLog[]
-}
-
-model Team {
-  id           Int           @id @default(autoincrement())
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  name         String
-  contributors Contributor[]
-  projectId    Int
-  project      Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  assignments  Assignment[]
-}
-
-model Column {
-  id          Int      @id @default(autoincrement())
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  name        String   @default("To Do") // Might not need this
-  tasks       Task[]
-  columnIndex Int
-  projectId   Int
-  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-}
-
+// this is our storage buckets!
 model Element {
   id          Int       @id @default(autoincrement())
   createdAt   DateTime  @default(now())
@@ -251,7 +247,8 @@ model Element {
   children    Element[] @relation("ElementToElement")
 }
 
-model Forms {
+// the forms that people created at the user level
+model Form {
   id        Int           @id @default(autoincrement())
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
@@ -261,6 +258,7 @@ model Forms {
   archived  Boolean       @default(false)
 }
 
+// this allows you to update forms but not bork up the tasks they are linked with
 model FormVersion {
   id        Int      @id @default(autoincrement())
   name      String
@@ -269,12 +267,13 @@ model FormVersion {
   schema    Json
   uiSchema  Json?
   createdAt DateTime @default(now())
-  Form      Forms    @relation(fields: [formId], references: [id], onDelete: Cascade)
-  Task      Task[]
+  form      Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  tasks     Task[]
 
   @@index([formId, version], name: "formVersionIndex")
 }
 
+// this is our notification system
 model Notification {
   id           Int      @id @default(autoincrement())
   createdAt    DateTime @default(now())
@@ -286,35 +285,36 @@ model Notification {
   project      Project? @relation(fields: [projectId], references: [id])
 }
 
-enum WidgetSize {
-  SMALL
-  MEDIUM
-  LARGE
-}
-
+// overall user dashboard widgets
 model Widget {
-  id       Int        @id @default(autoincrement())
+  id       Int     @id @default(autoincrement())
   userId   Int
-  user     User       @relation(fields: [userId], references: [id])
+  user     User    @relation(fields: [userId], references: [id])
   type     String // "LastProject", "Notifications", "OverdueTask", "UpcomingTask"
-  show     Boolean    @default(true)
+  show     Boolean @default(true)
   position Int
-  size     WidgetSize @default(MEDIUM)
 
   @@unique([userId, type])
 }
 
+// project level dashboard widgets
 model ProjectWidget {
-  id        Int                     @id @default(autoincrement())
+  id        Int                @id @default(autoincrement())
   userId    Int
-  user      User                    @relation(fields: [userId], references: [id])
+  user      User               @relation(fields: [userId], references: [id])
   projectId Int
-  project   Project                 @relation(fields: [projectId], references: [id])
+  project   Project            @relation(fields: [projectId], references: [id])
   type      String
-  show      Boolean                 @default(true)
+  show      Boolean            @default(true)
   position  Int
-  size      WidgetSize              @default(MEDIUM)
-  privilege ContributorPrivileges[] @default([CONTRIBUTOR, PROJECT_MANAGER])
+  size      WidgetSize         @default(MEDIUM)
+  privilege MemberPrivileges[] @default([CONTRIBUTOR, PROJECT_MANAGER])
 
   @@unique([userId, projectId, type])
+}
+
+enum WidgetSize {
+  SMALL
+  MEDIUM
+  LARGE
 }


### PR DESCRIPTION
Revising the schema after a lot of discussions with @doomlab and
@marton-balazs-kovacs. This reduces the amount of unnecessary
relations, and clarifies naming as much as possible.

See also #266 and #173 
