### PR TITLE
factored out assignment filtering to show own assignments

### DIFF
--- a/src/assignments/components/AssignmentCompletion.tsx
+++ b/src/assignments/components/AssignmentCompletion.tsx
@@ -5,11 +5,18 @@ import CompleteToggle from "./CompleteToggle"
 import { CompletedAs } from "db"
 import { useTaskContext } from "src/tasks/components/TaskContext"
 import { useCurrentContributor } from "src/contributors/hooks/useCurrentContributor"
+import { useFilterContributorAssignment } from "../hooks/useFilterContributorAssignment"
 
 export const AssignmentCompletion = () => {
   const { task, individualAssignments, teamAssignments } = useTaskContext()
 
   const { contributor: currentContributor } = useCurrentContributor(task.projectId)
+
+  const { filteredIndividualAssignments, filteredTeamAssignments } = useFilterContributorAssignment(
+    individualAssignments,
+    teamAssignments,
+    currentContributor!.id
+  )
 
   return (
     <div className="card bg-base-300 mx-2 w-1/2">
@@ -25,24 +32,28 @@ export const AssignmentCompletion = () => {
         />
 
         {/* if no schema complete task as a Individual*/}
-        {!task.formVersion && individualAssignments && individualAssignments.length > 0 && (
-          <div className="flex grid-col-2">
-            <CompleteToggle
-              currentAssignment={individualAssignments[0]}
-              completedLabel="Completed"
-              completedBy={currentContributor?.id}
-              completedAs={CompletedAs.INDIVIDUAL}
-            />
-            <span className="mx-2">
-              <AssignmentHistoryModal assignmentStatusLog={individualAssignments[0]!.statusLogs!} />
-            </span>
-          </div>
-        )}
+        {!task.formVersion &&
+          filteredIndividualAssignments &&
+          filteredIndividualAssignments.length > 0 && (
+            <div className="flex grid-col-2">
+              <CompleteToggle
+                currentAssignment={filteredIndividualAssignments[0]}
+                completedLabel="Completed"
+                completedBy={currentContributor?.id}
+                completedAs={CompletedAs.INDIVIDUAL}
+              />
+              <span className="mx-2">
+                <AssignmentHistoryModal
+                  assignmentStatusLog={filteredIndividualAssignments[0]!.statusLogs!}
+                />
+              </span>
+            </div>
+          )}
 
         {/* if no schema complete task as a Team*/}
-        {!task.formVersion && teamAssignments && teamAssignments.length > 0 && (
+        {!task.formVersion && filteredTeamAssignments && filteredTeamAssignments.length > 0 && (
           <div>
-            {teamAssignments.map((teamAssignment) => (
+            {filteredTeamAssignments.map((teamAssignment) => (
               <div key={teamAssignment.id} className="flex flex-col gap-2">
                 <CompleteToggle
                   currentAssignment={teamAssignment}
@@ -59,29 +70,31 @@ export const AssignmentCompletion = () => {
         )}
 
         {/* if schema and individual*/}
-        {task.formVersion && individualAssignments && individualAssignments.length > 0 && (
-          <div className="flex grid-col-2">
-            <CompleteSchema
-              currentAssignment={individualAssignments[0]}
-              completedBy={currentContributor?.id}
-              completedAs={CompletedAs.INDIVIDUAL}
-              schema={task.formVersion.schema}
-              ui={task.formVersion.uiSchema}
-            />
-            <span className="mx-2">
-              <AssignmentHistoryModal
-                assignmentStatusLog={individualAssignments[0]!.statusLogs!}
+        {task.formVersion &&
+          filteredIndividualAssignments &&
+          filteredIndividualAssignments.length > 0 && (
+            <div className="flex grid-col-2">
+              <CompleteSchema
+                currentAssignment={filteredIndividualAssignments[0]}
+                completedBy={currentContributor?.id}
+                completedAs={CompletedAs.INDIVIDUAL}
                 schema={task.formVersion.schema}
                 ui={task.formVersion.uiSchema}
               />
-            </span>
-          </div>
-        )}
+              <span className="mx-2">
+                <AssignmentHistoryModal
+                  assignmentStatusLog={filteredIndividualAssignments[0]!.statusLogs!}
+                  schema={task.formVersion.schema}
+                  ui={task.formVersion.uiSchema}
+                />
+              </span>
+            </div>
+          )}
 
         {/* if schema and team*/}
-        {task.formVersion && teamAssignments && teamAssignments.length > 0 && (
+        {task.formVersion && filteredTeamAssignments && filteredTeamAssignments.length > 0 && (
           <div className="">
-            {teamAssignments.map((teamAssignment) => (
+            {filteredTeamAssignments.map((teamAssignment) => (
               <div key={teamAssignment.id} className="mb-2 flex grid-col-2">
                 <CompleteSchema
                   currentAssignment={teamAssignment}

--- a/src/assignments/hooks/useAssignmentData.ts
+++ b/src/assignments/hooks/useAssignmentData.ts
@@ -1,7 +1,4 @@
 import { Assignment, AssignmentStatusLog, Contributor, Team, User } from "db"
-import { useCurrentUser } from "src/users/hooks/useCurrentUser"
-import getContributor from "src/contributors/queries/getContributor"
-import { useQuery } from "@blitzjs/rpc"
 import { ExtendedTask } from "src/tasks/components/TaskContext"
 
 // Creating custom types
@@ -34,26 +31,13 @@ export default function useAssignmentData(task: ExtendedTask): useAssignmentData
   // Get assignments
   const assignments = task.assignees
 
-  // Get currentContributor
-  const currentUser = useCurrentUser()
-  // TODO: Replace by hook
-  const [currentContributor] = useQuery(getContributor, {
-    where: { projectId: task.projectId, userId: currentUser!.id },
-  })
-
   // Filter out individual assignments
   const individualAssignments = assignments.filter(
-    (assignment) =>
-      assignment.contributorId !== null && assignment.contributorId == currentContributor.id
+    (assignment) => assignment.contributorId !== null
   )
 
   // Filter out team assignments
-  const teamAssignments = assignments.filter((assignment) => {
-    return (
-      assignment.teamId !== null &&
-      assignment.team?.contributors?.some((contributor) => contributor.id === currentContributor.id)
-    )
-  })
+  const teamAssignments = assignments.filter((assignment) => assignment.teamId !== null)
 
   return {
     individualAssignments,

--- a/src/assignments/hooks/useFilterContributorAssignment.ts
+++ b/src/assignments/hooks/useFilterContributorAssignment.ts
@@ -1,0 +1,31 @@
+import { ExtendedAssignment } from "./useAssignmentData"
+
+type UseFilterContributorAssignmentType = {
+  filteredIndividualAssignments: ExtendedAssignment[]
+  filteredTeamAssignments: ExtendedAssignment[]
+}
+
+export function useFilterContributorAssignment(
+  individualAssignments: ExtendedAssignment[],
+  teamAssignments: ExtendedAssignment[],
+  currentContributorId: number
+): UseFilterContributorAssignmentType {
+  // Filter out individual assignments
+  const filteredIndividualAssignments = individualAssignments.filter(
+    (assignment) =>
+      assignment.contributorId !== null && assignment.contributorId == currentContributorId
+  )
+
+  // Filter out team assignments
+  const filteredTeamAssignments = teamAssignments.filter((assignment) => {
+    return (
+      assignment.teamId !== null &&
+      assignment.team?.contributors?.some((contributor) => contributor.id === currentContributorId)
+    )
+  })
+
+  return {
+    filteredIndividualAssignments,
+    filteredTeamAssignments,
+  }
+}


### PR DESCRIPTION
Fix proposed to issue #288.

`TaskContext` now returns all the individual and team assignments.

`useFilterContributorAssignment` filters by the `currentContributor` Id. This filtering is only needed for `AssignmentCompletition`, but not in any other components that use the assignments from the `TaskContext`.