### PR TITLE
added option to archive forms

### DIFF
--- a/src/forms/components/ArchiveFormButton.tsx
+++ b/src/forms/components/ArchiveFormButton.tsx
@@ -1,0 +1,41 @@
+import { useMutation } from "@blitzjs/rpc"
+import archiveForm from "../mutations/archiveForm"
+import toast from "react-hot-toast"
+import { Forms } from "@prisma/client"
+import { TrashIcon } from "@heroicons/react/24/outline"
+
+interface ArchiveFormButtonProps {
+  formId: number
+  onArchived?: (form: Forms) => void // Optional callback for when the form is archived
+}
+
+const ArchiveFormButton = ({ formId, onArchived }: ArchiveFormButtonProps) => {
+  const [archiveFormMutation] = useMutation(archiveForm)
+
+  const handleArchive = async () => {
+    const isConfirmed = window.confirm(
+      "The form will be deleted. You cannot assign it to tasks anymore, but contributors can still finish tasks with this form assigned. Are you sure to continue?"
+    )
+
+    if (!isConfirmed) {
+      return
+    }
+
+    try {
+      const form = await archiveFormMutation({ formId })
+      toast.success("Form deleted successfully!")
+      if (onArchived) onArchived(form) // Trigger any additional logic when the form is archived
+    } catch (error) {
+      console.error("Failed to delete form:", error)
+      toast.error("There was an error deleting the form.")
+    }
+  }
+
+  return (
+    <button className="btn btn-primary" onClick={handleArchive}>
+      <TrashIcon className="h-5 w-5 text-white" aria-hidden="true" />
+    </button>
+  )
+}
+
+export default ArchiveFormButton

--- a/src/forms/components/FormsTable.tsx
+++ b/src/forms/components/FormsTable.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { Routes } from "@blitzjs/next"
 import { JsonFormModal } from "src/core/components/JsonFormModal"
 import DateFormat from "src/core/components/DateFormat"
+import ArchiveFormButton from "./ArchiveFormButton"
 
 export interface FormWithFormVersion extends Forms {
   formVersion: FormVersion | null
@@ -64,5 +65,12 @@ export const formsTableColumns = [
       </Link>
     ),
     header: "Edit",
+  }),
+  columnHelper.accessor("id", {
+    id: "delete",
+    enableColumnFilter: false,
+    enableSorting: false,
+    cell: (info) => <ArchiveFormButton formId={info.getValue()} />,
+    header: "Delete",
   }),
 ]

--- a/src/forms/mutations/archiveForm.ts
+++ b/src/forms/mutations/archiveForm.ts
@@ -1,0 +1,16 @@
+import { resolver } from "@blitzjs/rpc"
+import { ArchiveFormSchema } from "../schemas"
+import db from "db"
+
+export default resolver.pipe(
+  resolver.zod(ArchiveFormSchema),
+  resolver.authorize(),
+  async ({ formId }) => {
+    const form = await db.forms.update({
+      where: { id: formId },
+      data: { archived: true },
+    })
+
+    return form
+  }
+)

--- a/src/forms/schemas.ts
+++ b/src/forms/schemas.ts
@@ -88,3 +88,7 @@ export const EditFormSchema = z.object({
 export const AddFormTemplatesSchema = z.object({
   selectedFormIds: z.array(z.number()),
 })
+
+export const ArchiveFormSchema = z.object({
+  formId: z.number(),
+})

--- a/src/pages/forms/index.tsx
+++ b/src/pages/forms/index.tsx
@@ -22,6 +22,7 @@ const AllFormsPage = () => {
   const [{ forms }, { refetch }] = useQuery(getForms, {
     where: {
       user: { id: currentUser?.id },
+      archived: false,
     },
     orderBy: { id: "asc" },
   })

--- a/src/tasks/components/TaskSchemaInput.tsx
+++ b/src/tasks/components/TaskSchemaInput.tsx
@@ -15,7 +15,7 @@ export const TaskSchemaInput = ({ contributors }) => {
     .map((pm) => pm.userId)
 
   const [pmForms] = useQuery(getForms, {
-    where: { userId: { in: pmList } },
+    where: { userId: { in: pmList }, archived: false },
     include: { user: true },
   })
 


### PR DESCRIPTION
A quick and dirty solution to issue #298. Forms can be archived and they should not be assignable to tasks anymore and they do not show up in the forms list. However, if they are still available for a project if they have been assigned to a task.

To keep the db clean we have to add conditional logic later to delete forms permanently. 