### PR TITLE
Add dry run action

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies and generate Prisma client
+        run: |
+          npm install
+          npx blitz prisma generate
+
+      - name: Run build
+        run: npm run build

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,12 +1,7 @@
 name: Build and Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds an action to automatically check whether the build process completes upon a pull request. **NOT** urgent 😊

In effect, it runs the following commands:

```sh
npm install
npx blitz prisma generate
npm run build
```

This means it will need the environment variables to complete the build:

```
RESEND_API_KEY='resend_api_key'
```

I tested it with literally what is up there ☝️ and fake env variables also seems to work for the dry run. It will throw an error if the `RESEND_API_KEY` is missing altogether, not whether it is valid. The other environment variables are not completely necessary, but I include here to be encompassing:

```
DATABASE_URL='postgres://postgres:password@localhost:5432/development'
EMAIL_PASS='password'
ACCESS_KEY='access_key'
SECRET_ACCESS_KEY='secret_access_key'
ORCID_CLIENT_SANDBOX=true
ORCID_CLIENT_ID='orcid_client_id'
ORCID_CLIENT_SECRET='orcid_client_secret'
```

## How to add repo secrets

You can find some additional information in [the GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-environment), but here's a recording to help in adding the secret to the repo:


https://github.com/user-attachments/assets/40ec6cba-fe83-4e87-a48a-8f3dad76d594

This action will only succeed once the `RESEND_API_KEY` is included in the repo secrets. I would strongly strongly strongly recommend to **not** use the production key here. Compartmentalizing test secrets/keys and production is very helpful (also because [deleted repo's are not really deleted on GitHub at any time](https://trufflesecurity.com/blog/anyone-can-access-deleted-and-private-repo-data-github)).