### PR TITLE
Remove dynamic page titles + include in Layout consistently

### DIFF
--- a/src/pages/forms/[formsId]/edit.tsx
+++ b/src/pages/forms/[formsId]/edit.tsx
@@ -30,11 +30,7 @@ const FormEditPage = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Form Builder</title>
-      </Head>
-
+    <Layout title="Form Builder">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <Suspense fallback={<div>Loading...</div>}>
           <FormPlayground

--- a/src/pages/forms/index.tsx
+++ b/src/pages/forms/index.tsx
@@ -28,11 +28,7 @@ const AllFormsPage = () => {
   })
 
   return (
-    <Layout>
-      <Head>
-        <title>All Forms</title>
-      </Head>
-
+    <Layout title="All Forms">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <Suspense fallback={<div>Loading...</div>}>
           <FormsList forms={forms} addPagination={true} />

--- a/src/pages/forms/new.tsx
+++ b/src/pages/forms/new.tsx
@@ -23,11 +23,7 @@ const FormBuilderPage = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Form Builder</title>
-      </Head>
-
+    <Layout title="Form Builder">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <Suspense fallback={<div>Loading...</div>}>
           <FormPlayground saveForm={saveForm} />

--- a/src/pages/help/index.tsx
+++ b/src/pages/help/index.tsx
@@ -4,10 +4,7 @@ import Head from "next/head"
 
 const HelpPage = () => {
   return (
-    <Layout>
-      <Head>
-        <title>Get Help</title>
-      </Head>
+    <Layout title="Get Help">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="text-3xl flex justify-center mb-2">Get Help</h1>
 

--- a/src/pages/invites/index.tsx
+++ b/src/pages/invites/index.tsx
@@ -48,11 +48,7 @@ const InvitesPage = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Project Invitations</title>
-      </Head>
-
+    <Layout title="Project Invitations">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Project Invitations</h1>
 

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -74,10 +74,7 @@ const MainContent = () => {
 }
 
 export const MainPage = () => (
-  <Layout>
-    <Head>
-      <title>Home</title>
-    </Head>
+  <Layout title="Home">
     <Suspense fallback={<div>Loading...</div>}>
       <MainContent />
     </Suspense>

--- a/src/pages/notifications/index.tsx
+++ b/src/pages/notifications/index.tsx
@@ -49,9 +49,6 @@ const NotificationContent = () => {
 
   return (
     <>
-      <Head>
-        <title>All Notifications</title>
-      </Head>
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">All Notifications</h1>
         <Table columns={columns} data={notificationTableData} addPagination={true} />
@@ -61,7 +58,7 @@ const NotificationContent = () => {
 }
 const NotificationsPage = () => {
   return (
-    <Layout>
+    <Layout title="All Notifications">
       <Suspense fallback={<div>Loading...</div>}>
         <NotificationContent />
       </Suspense>

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -14,7 +14,7 @@ const EditProfilePage = () => {
 
 EditProfilePage.authenticate = true
 EditProfilePage.getLayout = (page) => {
-  return <Layout>{page}</Layout>
+  return <Layout title="Edit Profile">{page}</Layout>
 }
 
 export default EditProfilePage

--- a/src/pages/profile/password.tsx
+++ b/src/pages/profile/password.tsx
@@ -14,7 +14,7 @@ const EditPasswordPage = () => {
 
 EditPasswordPage.authenticate = true
 EditPasswordPage.getLayout = (page) => {
-  return <Layout>{page}</Layout>
+  return <Layout title="Edit Password">{page}</Layout>
 }
 
 export default EditPasswordPage

--- a/src/pages/projects/[projectId].tsx
+++ b/src/pages/projects/[projectId].tsx
@@ -25,9 +25,6 @@ const ShowProjectContent = () => {
 
   return (
     <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
-      <Head>
-        <title>Project {project.name}</title>
-      </Head>
       {privilege == MemberPrivileges.PROJECT_MANAGER && (
         <AnnouncementModal projectId={projectId!} refreshWidgets={refreshWidgets} />
       )}
@@ -38,7 +35,7 @@ const ShowProjectContent = () => {
 
 export const ShowProjectPage = () => {
   return (
-    <Layout>
+    <Layout title="Project page">
       <Suspense fallback={<div>Loading...</div>}>
         <ShowProjectContent />
       </Suspense>

--- a/src/pages/projects/[projectId]/contributors/[contributorId].tsx
+++ b/src/pages/projects/[projectId]/contributors/[contributorId].tsx
@@ -20,10 +20,6 @@ export const ContributorPage = () => {
 
   return (
     <>
-      <Head>
-        <title>{contributorUser!.username} Contributions</title>
-      </Head>
-
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <ContributorInformation
           projectId={projectId!}
@@ -52,7 +48,7 @@ export const ContributorPage = () => {
 
 const ShowContributorPage = () => {
   return (
-    <Layout>
+    <Layout title="Contributions">
       <Suspense fallback={<div>Loading...</div>}>
         <ContributorPage />
       </Suspense>

--- a/src/pages/projects/[projectId]/contributors/[contributorId]/edit.tsx
+++ b/src/pages/projects/[projectId]/contributors/[contributorId]/edit.tsx
@@ -150,10 +150,7 @@ const EditContributorPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Edit Contributor</title>
-      </Head>
+    <Layout title="Edit Contributor">
       <Suspense fallback={<div>Loading...</div>}>
         <EditContributor />
       </Suspense>

--- a/src/pages/projects/[projectId]/contributors/index.tsx
+++ b/src/pages/projects/[projectId]/contributors/index.tsx
@@ -43,11 +43,7 @@ const ContributorsPage = () => {
   const currentUser = useCurrentUser()
 
   return (
-    <Layout>
-      <Head>
-        <title>All Contributors</title>
-      </Head>
-
+    <Layout title="All Contributors">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Contributors</h1>
         <Suspense fallback={<Loading />}>

--- a/src/pages/projects/[projectId]/contributors/invites.tsx
+++ b/src/pages/projects/[projectId]/contributors/invites.tsx
@@ -14,11 +14,7 @@ const InvitesPagePM = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Project Contributor Invitations</title>
-      </Head>
-
+    <Layout title="Project Contributor Invitations">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Invited Contributors</h1>
 

--- a/src/pages/projects/[projectId]/contributors/new.tsx
+++ b/src/pages/projects/[projectId]/contributors/new.tsx
@@ -39,10 +39,7 @@ const NewContributorPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Invite New Contributor</title>
-      </Head>
+    <Layout title="Invite New Contributor">
       <Suspense fallback={<div>Loading...</div>}>
         <NewContributor />
       </Suspense>

--- a/src/pages/projects/[projectId]/edit.tsx
+++ b/src/pages/projects/[projectId]/edit.tsx
@@ -88,10 +88,6 @@ export const EditProject = () => {
 
   return (
     <>
-      <Head>
-        <title>Edit {project.name}</title>
-      </Head>
-
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Project Settings</h1>
         <Suspense fallback={<div>Loading...</div>}>
@@ -119,7 +115,7 @@ const EditProjectPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
+    <Layout title="Edit Project">
       <Suspense fallback={<div>Loading...</div>}>
         <EditProject />
       </Suspense>

--- a/src/pages/projects/[projectId]/elements/[elementId].tsx
+++ b/src/pages/projects/[projectId]/elements/[elementId].tsx
@@ -21,10 +21,7 @@ const ShowElementPage = () => {
   const [element, { refetch }] = useQuery(getElement, { id: elementId })
 
   return (
-    <Layout>
-      <Head>
-        <title>Element {element.id}</title>
-      </Head>
+    <Layout title="Element Page">
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <div>
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/elements/[elementId]/edit.tsx
+++ b/src/pages/projects/[projectId]/elements/[elementId]/edit.tsx
@@ -38,11 +38,7 @@ export const EditElement = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Edit Element {element.id}</title>
-      </Head>
-
+    <Layout title="Edit Element Page">
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title={`Edit ${element.name}`} />
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/elements/index.tsx
+++ b/src/pages/projects/[projectId]/elements/index.tsx
@@ -18,11 +18,7 @@ const Elements = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Elements</title>
-      </Head>
-
+    <Layout title="Elements">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Elements</h1>
         <SearchButton onChange={handleSearch}></SearchButton>

--- a/src/pages/projects/[projectId]/elements/new.tsx
+++ b/src/pages/projects/[projectId]/elements/new.tsx
@@ -21,10 +21,7 @@ const NewElementPage = () => {
   const [createElementMutation] = useMutation(createElement)
 
   return (
-    <Layout>
-      <Head>
-        <title>Create New Element</title>
-      </Head>
+    <Layout title="Create New Element">
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title="Create New Element" />
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/forms/index.tsx
+++ b/src/pages/projects/[projectId]/forms/index.tsx
@@ -9,14 +9,9 @@ const MetadataPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Form Data</title>
-      </Head>
-
+    <Layout title="Form Data">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Form Data</h1>
-
         {
           <Suspense fallback={<div>Loading...</div>}>
             <ProjectFormsList />

--- a/src/pages/projects/[projectId]/notifications/index.tsx
+++ b/src/pages/projects/[projectId]/notifications/index.tsx
@@ -38,9 +38,6 @@ const NotificationContent = () => {
 
   return (
     <>
-      <Head>
-        <title>Project Notifications</title>
-      </Head>
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Project Notifications</h1>
         <Table columns={columns} data={projectNotificationTableData} addPagination={true} />
@@ -51,7 +48,7 @@ const NotificationContent = () => {
 
 const ProjectNotificationsPage = () => {
   return (
-    <Layout>
+    <Layout title="Project Notifications">
       <Suspense fallback={<div>Loading...</div>}>
         <NotificationContent />
       </Suspense>

--- a/src/pages/projects/[projectId]/roles/index.tsx
+++ b/src/pages/projects/[projectId]/roles/index.tsx
@@ -53,11 +53,7 @@ const RolesPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Assign Roles</title>
-      </Head>
-
+    <Layout title="Assign Roles">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         {
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/summary/index.tsx
+++ b/src/pages/projects/[projectId]/summary/index.tsx
@@ -188,10 +188,7 @@ const SummaryPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Project Summary</title>
-      </Head>
+    <Layout title="Project Summary">
       <Suspense fallback={<div>Loading...</div>}>
         <Summary />
       </Suspense>

--- a/src/pages/projects/[projectId]/tasks/[taskId].tsx
+++ b/src/pages/projects/[projectId]/tasks/[taskId].tsx
@@ -15,9 +15,6 @@ const TaskContent = () => {
 
   return (
     <>
-      <Head>
-        <title>Task {task.name}</title>
-      </Head>
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <div className="flex flex-row justify-center m-2">
           <TaskInformation />
@@ -33,7 +30,7 @@ const TaskContent = () => {
 
 // Show the task page
 export const ShowTaskPage = () => (
-  <Layout>
+  <Layout title="Task Page">
     <TaskLayout>
       <Suspense fallback={<div>Loading...</div>}>
         <TaskContent />

--- a/src/pages/projects/[projectId]/tasks/[taskId]/edit.tsx
+++ b/src/pages/projects/[projectId]/tasks/[taskId]/edit.tsx
@@ -90,10 +90,6 @@ export const EditTask = () => {
 
   return (
     <>
-      <Head>
-        <title>Edit {task.name}</title>
-      </Head>
-
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title={`Edit ${task.name}`} />
         <Suspense fallback={<div>Loading...</div>}>
@@ -121,7 +117,7 @@ const EditTaskPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
+    <Layout title="Edit Task Page">
       <TaskLayout>
         <Suspense fallback={<div>Loading...</div>}>
           <EditTask />

--- a/src/pages/projects/[projectId]/tasks/[taskId]/metadata.tsx
+++ b/src/pages/projects/[projectId]/tasks/[taskId]/metadata.tsx
@@ -31,9 +31,6 @@ const MetadataContent = () => {
 
   return (
     <>
-      <Head>
-        <title>Form Data for {task.name}</title>
-      </Head>
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         {/* Header */}
         <div className="flex flex-row justify-center">
@@ -92,7 +89,7 @@ const MetadataContent = () => {
 
 export const ShowMetadataPage = () => {
   return (
-    <Layout>
+    <Layout title="Form Data Page">
       <Suspense fallback={<div>Loading...</div>}>
         <TaskLayout>
           <MetadataContent />

--- a/src/pages/projects/[projectId]/tasks/index.tsx
+++ b/src/pages/projects/[projectId]/tasks/index.tsx
@@ -10,11 +10,7 @@ const TasksPage = () => {
   const { privilege } = useMemberPrivileges()
 
   return (
-    <Layout>
-      <Head>
-        <title>Tasks</title>
-      </Head>
-
+    <Layout title="Tasks">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <Suspense fallback={<div>Loading...</div>}>
           <ProjectTasksTabs projectPrivilege={privilege} projectId={projectId} />

--- a/src/pages/projects/[projectId]/tasks/new.tsx
+++ b/src/pages/projects/[projectId]/tasks/new.tsx
@@ -44,10 +44,7 @@ const NewTaskPage = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Create New Task</title>
-      </Head>
+    <Layout title="Create New Task">
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title="Create New Task" />
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/teams/[teamId].tsx
+++ b/src/pages/projects/[projectId]/teams/[teamId].tsx
@@ -25,10 +25,6 @@ export const TeamPage = () => {
 
   return (
     <>
-      <Head>
-        <title>Team {team.name}</title>
-      </Head>
-
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <TeamInformation team={team} privilege={privilege!} />
 
@@ -48,7 +44,7 @@ export const TeamPage = () => {
 
 const ShowTeamPage = () => {
   return (
-    <Layout>
+    <Layout title="Team Page">
       <Suspense fallback={<div>Loading...</div>}>
         <TeamPage />
       </Suspense>

--- a/src/pages/projects/[projectId]/teams/[teamId]/edit.tsx
+++ b/src/pages/projects/[projectId]/teams/[teamId]/edit.tsx
@@ -71,10 +71,6 @@ export const EditTeam = () => {
 
   return (
     <>
-      <Head>
-        <title>Edit {teamProjectMember.name}</title>
-      </Head>
-
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title={`Edit ${teamProjectMember.name}`} />
         <Suspense fallback={<div>Loading...</div>}>
@@ -102,7 +98,7 @@ const EditTeamPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
+    <Layout title="Edit Team Page">
       <Suspense fallback={<div>Loading...</div>}>
         <EditTeam />
       </Suspense>

--- a/src/pages/projects/[projectId]/teams/index.tsx
+++ b/src/pages/projects/[projectId]/teams/index.tsx
@@ -63,11 +63,7 @@ const TeamsPage = () => {
   const { privilege } = useMemberPrivileges()
 
   return (
-    <Layout>
-      <Head>
-        <title>All Teams</title>
-      </Head>
-
+    <Layout title="All Teams">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">Teams</h1>
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/[projectId]/teams/new.tsx
+++ b/src/pages/projects/[projectId]/teams/new.tsx
@@ -62,10 +62,7 @@ const NewTeamPage = () => {
   useProjectMemberAuthorization([MemberPrivileges.PROJECT_MANAGER])
 
   return (
-    <Layout>
-      <Head>
-        <title>Add New Team</title>
-      </Head>
+    <Layout title="Add New Team">
       <main className="flex flex-col mb-2 mt-2 mx-auto w-full max-w-7xl">
         <PageHeader title="Add New Team" />
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -14,11 +14,7 @@ const ProjectsPage = () => {
   }
 
   return (
-    <Layout>
-      <Head>
-        <title>Projects</title>
-      </Head>
-
+    <Layout title="Projects">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">All Projects</h1>
 

--- a/src/pages/roles/index.tsx
+++ b/src/pages/roles/index.tsx
@@ -20,11 +20,7 @@ const RoleBuilderPage = () => {
   )
 
   return (
-    <Layout>
-      <Head>
-        <title>Contribution Roles</title>
-      </Head>
-
+    <Layout title="Contribution Roles">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="flex justify-center mb-2 text-3xl">All Roles</h1>
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -6,11 +6,7 @@ import PageHeader from "src/core/components/PageHeader"
 
 const AllTasksPage = () => {
   return (
-    <Layout>
-      <Head>
-        <title>All Tasks</title>
-      </Head>
-
+    <Layout title="All Tasks">
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <PageHeader className="flex justify-center mb-2" title="All Tasks" />
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/profile/components/EditPassword.tsx
+++ b/src/profile/components/EditPassword.tsx
@@ -18,10 +18,6 @@ export const EditPassword = () => {
 
   return (
     <>
-      <Head>
-        <title>Edit Password</title>
-      </Head>
-
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="text-3xl flex mb-2">Edit Password</h1>
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/profile/components/EditProfile.tsx
+++ b/src/profile/components/EditProfile.tsx
@@ -38,10 +38,6 @@ export const EditProfile = () => {
 
   return (
     <>
-      <Head>
-        <title>Edit Profile</title>
-      </Head>
-
       <main className="flex flex-col mt-2 mx-auto w-full max-w-7xl">
         <h1 className="text-3xl flex mb-2">Edit Profile</h1>
         <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
This PR does two things:

1. Remove all dyanmic page titles in favor of static page titles. Fixes #205.
2. Move all the page titles into the `Layout` component, where that component was already available.

(1) is a fix for #205, although dynamic page titles may need to be reintroduced later if people express benefit from this. If this is the case, note that we will need to use `getServerSideProps` to ensure the information is available upon page load, instead of a hook, which causes the flickering.

(2) was something I noticed, and I figured could help streamline the code. It is a minor thing but when adding up tens of these minor fixes across PRs, they start adding up 😊
