### PR TITLE
Streamline table columns

### DIFF
--- a/src/teams/tables/columns/PmTeamColumns.tsx
+++ b/src/teams/tables/columns/PmTeamColumns.tsx
@@ -3,35 +3,13 @@ import { createColumnHelper } from "@tanstack/react-table"
 import Link from "next/link"
 import { Routes } from "@blitzjs/next"
 import { TeamData } from "../processing/processTeam"
+import { ContributorTeamColumns } from "./ContributorTeamColumns"
 
 // Column helper
 const columnHelper = createColumnHelper<TeamData>()
 
 // ColumnDefs
-export const PmTeamColumns = [
-  columnHelper.accessor("name", {
-    cell: (info) => <span>{info.getValue()}</span>,
-    header: "Team Name",
-  }),
-  columnHelper.accessor("id", {
-    id: "view",
-    header: "View",
-    enableColumnFilter: false,
-    enableSorting: false,
-    cell: (info) => (
-      <div className="">
-        <Link
-          className="btn btn-primary"
-          href={Routes.ShowTeamPage({
-            projectId: info.row.original.projectId!,
-            teamId: info.getValue(),
-          })}
-        >
-          See Contributions
-        </Link>
-      </div>
-    ),
-  }),
+ContributorTeamColumns.push(
   columnHelper.accessor("id", {
     id: "edit",
     header: "Edit",
@@ -50,5 +28,6 @@ export const PmTeamColumns = [
         </Link>
       </div>
     ),
-  }),
-]
+  })
+)
+export const PmTeamColumns = ContributorTeamColumns


### PR DESCRIPTION
This PR streamlines the table columns, to deduplicate some of the column code.

I did some testing, but not super thorough, given that I am not 100% of where everything is used. In essence I only deduplicated where the columns were equivalent, or where only the label differed.

UPDATE: I force-pushed here to remove some changes that ended up not passing the typechecks, which the automation caught. It appears the column helper has types that I was not aware of while suggesting the first, more comprehensive changes.