### PR TITLE
Add slight delay to login reroute

### DIFF
--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -13,10 +13,14 @@ const LoginPage: BlitzPage = () => {
       </Head>
       <main className="flex flex-col h-screen">
         <LoginForm
-          onSuccess={(_user) => {
+          onSuccess={async (_user) => {
             const next = router.query.next
               ? decodeURIComponent(router.query.next as string)
               : "/main"
+
+            // Sleep for .1 seconds to prevent too fast navigation
+            await new Promise((resolve) => setTimeout(resolve, 100))
+
             return router.push(next)
           }}
         />


### PR DESCRIPTION
This PR patches the issue that resulted in an error "User ID required" after logging in.

After debugging this, I noticed the issue was not in the `/main` page, but in the reroute after successfully logging in. A .1 second delay patched the issue, in the sense that I could no longer produce the error locally.
